### PR TITLE
Use android-packageName if it exists

### DIFF
--- a/set-viewport.js
+++ b/set-viewport.js
@@ -28,7 +28,7 @@ function getConfig(ctx) {
 
     var projectRoot = ctx.opts.projectRoot;
     var config = new ConfigParser(path.join(projectRoot, 'config.xml'));
-    var packageName = config.packageName();
+    var packageName = config.android_packageName() || config.packageName();
     var activityName = config.android_activityName() || 'MainActivity';
     var packagePath = packageName.replace(/\./g, path.sep);
 


### PR DESCRIPTION
Hi, thank you for your useful plugin.
I found the following error occured if android-packageName attribute is used in config.xml.
```
ENOENT: no such file or directory, open '.../MainActivity.java'
```
So I fixed to use it if exists.